### PR TITLE
Add Point Calculator for Japan HSP Visa (2026)

### DIFF
--- a/skilled.md
+++ b/skilled.md
@@ -109,10 +109,7 @@
 - Intro: Activities of engaging in work requiring specialized knowledge or skills in the field of natural sciences or humanities based on a contract entered into with a public or private organization in Japan.
 - Length of Stay: 5 years (maximum)
 - Minimum Points: 70
-- Point Calculator: [HSP Visa Points Simulator (2026)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/)
-- Free interactive simulator built on the official 2026 Immigration Bureau point table. Calculates age-salary correlation, JLPT mutual exclusivity, and IPA certification bonuses. Identifies exact delta to reach the 80-point "1-year PR fast-track" threshold.
-
-  
+- [Point Calculator(HSP Visa)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/)  
 
 ### Ireland
 

--- a/skilled.md
+++ b/skilled.md
@@ -109,10 +109,9 @@
 - Intro: Activities of engaging in work requiring specialized knowledge or skills in the field of natural sciences or humanities based on a contract entered into with a public or private organization in Japan.
 - Length of Stay: 5 years (maximum)
 - Minimum Points: 70
+- Point Calculator: [HSP Visa Points Simulator (2026)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/)
+- Free interactive simulator built on the official 2026 Immigration Bureau point table. Calculates age-salary correlation, JLPT mutual exclusivity, and IPA certification bonuses. Identifies exact delta to reach the 80-point "1-year PR fast-track" threshold.
 
-##### [HSP Visa Points Simulator (2026)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/) 
-
-- Free interactive simulator for Japan's Highly Skilled Professional (HSP) visa. Built on the official 2026 Immigration Bureau point table. Calculates age-salary correlation, JLPT mutual exclusivity, and IPA certification bonuses. Identifies exact points needed to reach the 80-point "1-year PR fast-track" threshold.
   
 
 ### Ireland

--- a/skilled.md
+++ b/skilled.md
@@ -110,6 +110,11 @@
 - Length of Stay: 5 years (maximum)
 - Minimum Points: 70
 
+##### [HSP Visa Points Simulator (2026)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/) 
+
+- Free interactive simulator for Japan's Highly Skilled Professional (HSP) visa. Built on the official 2026 Immigration Bureau point table. Calculates age-salary correlation, JLPT mutual exclusivity, and IPA certification bonuses. Identifies exact points needed to reach the 80-point "1-year PR fast-track" threshold.
+  
+
 ### Ireland
 
 #### [Employment Visa](https://www.irishimmigration.ie/coming-to-work-in-ireland/what-are-my-work-visa-options/applying-for-a-long-stay-employment-visa/employment-visa/)

--- a/skilled.md
+++ b/skilled.md
@@ -109,7 +109,7 @@
 - Intro: Activities of engaging in work requiring specialized knowledge or skills in the field of natural sciences or humanities based on a contract entered into with a public or private organization in Japan.
 - Length of Stay: 5 years (maximum)
 - Minimum Points: 70
-- [Point Calculator(HSP Visa)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/)  
+- [Point Calculator (HSP Visa)](https://japan-refactor.com/high-skilled-professional-visa-japan-engineer/)  
 
 ### Ireland
 


### PR DESCRIPTION
Hi, I'd like to suggest adding a Point Calculator entry to the Japan section.

Other countries in this list (Australia, Canada, New Zealand, Hong Kong, Singapore) 
already have Point Calculator entries — Japan's section was missing one.

This free simulator is built on the official 2026 HSP point table (Natural Sciences/Engineering),
with correct age-salary correlation, JLPT mutual exclusivity logic, and IPA certification bonuses.
Identifies exact points needed to reach the 80-point "1-year PR fast-track" threshold.

Happy to make any adjustments if needed. Thank you for your consideration!